### PR TITLE
Reload on URL changes on page '0'

### DIFF
--- a/src/paginate-anything.js
+++ b/src/paginate-anything.js
@@ -213,7 +213,11 @@
             if($scope.passive === 'true') { return; }
 
             if(newUrl !== oldUrl) {
-              $scope.page = 0;
+              if($scope.page === 0){
+                $scope.reloadPage = true;
+              } else {
+                $scope.page = 0;
+              }
             }
           });
 


### PR DESCRIPTION
When the URL property changes and we're on page 0 the reload does not work because the $watch on the page property ignores changes of the same value. So lets do a reload on page 0 and change the page to 0 otherwise when the url changes. Fixes #30
