### PR TITLE
This fixes begriffs/angular-paginate-anything#68

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Response
 ```HTTP
 HTTP/1.1 206 Partial Content
 Accept-Ranges: items
-Content-Range: 0-24/100
+Content-Range: items 0-24/100
 Range-Unit: items
 Content-Type: application/json
 
@@ -275,12 +275,12 @@ Content-Type: application/json
 
 In short your server parses the `Range` header to find the zero-based
 start and end item. It includes a `Content-Range` header in the
-response disclosing the range it chooses to return, along with the
+response disclosing the unit and range it chooses to return, along with the
 total items after a slash, where total items can be "*" meaning
 unknown or infinite.
 
 When there are zero elements to return your server should send
-status code 204 (no content), `Content-Range: */0`, and an empty
+status code 204 (no content), `Content-Range: items */0`, and an empty
 body.
 
 To do all this header stuff you'll need to enable CORS on your server.

--- a/README.md
+++ b/README.md
@@ -241,7 +241,11 @@ side libraries.
     </tr>
     <tr>
       <td>ServiceStack for .NET</td>
-      <td><a href="https://github.com/begriffs/angular-paginate-anything/wiki/How-to-configure-.NET">.NET howto</a></td>
+      <td><a href="https://github.com/begriffs/angular-paginate-anything/wiki/How-to-configure-ServiceStack-for-.NET">Service Stack .NET howto</a></td>
+    </tr>
+    <tr>
+      <td>ASP.NET Web API</td>
+      <td><a href="https://github.com/begriffs/angular-paginate-anything/wiki/How-To-Configure-ASP.NET-Web-API">ASP.NET Web API howto</a></td>
     </tr>
   </tbody>
 </table>

--- a/src/paginate-anything.js
+++ b/src/paginate-anything.js
@@ -333,7 +333,7 @@
 
 
   function parseRange(hdr) {
-    var m = hdr && hdr.match(/^(\d+)-(\d+)\/(\d+|\*)$/);
+    var m = hdr && hdr.match(/^items (\d+)-(\d+)\/(\d+|\*)$/);
     if(m) {
       return {
         from: +m[1],

--- a/src/paginate-anything.js
+++ b/src/paginate-anything.js
@@ -333,7 +333,7 @@
 
 
   function parseRange(hdr) {
-    var m = hdr && hdr.match(/^items (\d+)-(\d+)\/(\d+|\*)$/);
+    var m = hdr && hdr.match(/^(?:items )?(\d+)-(\d+)\/(\d+|\*)$/);
     if(m) {
       return {
         from: +m[1],


### PR DESCRIPTION
since directive is opinionated on the Range-Unit being "items", we'll
make sure the content header includes the unit value.
Also updated the README file to address this.

The simple little change to the Regex that matches the header value now ensures this works according to the RFC spec.

This is a breaking change from the previous behavior for anyone who used this in the past as the README instructed.

Ideally, we could expose an optional property from the directive to allow folks to set the unit used by the Range-Unit header, which defaults to "items".  Then use that value in the regex, instead of a hardcoded value.