### PR TITLE
Bugfix: updating url to return more than one page

### DIFF
--- a/src/paginate-anything.js
+++ b/src/paginate-anything.js
@@ -274,10 +274,11 @@
             if($scope.passive === 'true') { return; }
 
             if(newVal === true && oldVal === false) {
+              var pp = $scope.perPage || defaultPerPage;
               $scope.reloadPage = false;
               requestRange({
-                from: $scope.page * $scope.perPage,
-                to: ($scope.page+1) * $scope.perPage - 1
+                from: $scope.page * pp,
+                to: ($scope.page+1) * pp - 1
               });
             }
           });


### PR DESCRIPTION
Pagination never appears when it initially had only one page, then `reloadPage` triggers it to have multiple pages.