### PR TITLE
Ability to provide callback function to search and trigger a reload from the controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,18 +163,23 @@ param can be a scope variable as well as a hard-coded string.
     </tr>
     <tr>
       <td>transform-response</td>
-      <td>Function that will get called once the http response has returned.  See <a href="https://docs.angularjs.org/api/ng/service/$http">Angular's $https documentation</td> for more information.
+      <td>Function that will get called once the http response has returned. See <a href="https://docs.angularjs.org/api/ng/service/$http">Angular's $https documentation for more information.</td>
       <td>Read/write. Changing it will reset to the first page.</td>
     </tr>
     <tr>
       <td>method</td>
-      <td>Type of request method. Can be either GET or POST. Default is GET.
+      <td>Type of request method. Can be either GET or POST. Default is GET.</td>
       <td>Read/write.</td>
     </tr>
     <tr>
       <td>postData</td>
-      <td>An array of data to be sent when method is set to POST.
+      <td>An array of data to be sent when method is set to POST.</td>
       <td>Read/write.</td>
+    </tr>
+    <tr>
+      <td>load-fn</td>
+      <td>A callback function to perform the request. Gets the http config as parameter and must return a promise.</td>
+      <td>Write-only.</td>
     </tr>
   </tbody>
 </table>
@@ -196,6 +201,14 @@ $scope.$on('pagination:loadPage', function (event, status, config) {
 
 The `pagination:loadStart` is passed the client request rather than
 the server response.
+
+To trigger a reload the `pagination:reload` event can be send:
+
+```js
+function () {
+  $scope.$broadcast('pagination:reload');
+}
+```
 
 ### How to deal with sorting, filtering and facets?
 
@@ -313,6 +326,38 @@ end
 
 For a more complete implementation including other appropriate responses
 see my [clean_pagination](https://github.com/begriffs/clean_pagination) gem.
+
+### Using the load-fn callback
+
+Instead of having paginate-anything handle the http requests there is the option of using a callback function to perform the requests. This might be helpful e.g. if the data does not come from http endpoints, further processing of the request needs to be done prior to submitting the request or further processing of the response is necessary.
+
+The callback can be used as follows:
+
+```html
+<bgf-pagination collection="data" page="filter.page" per-page="filter.perpage" load-fn="callback(config)"></bgf-pagination>
+```
+
+```js
+$scope.callback = function (config) {
+  return $http(config);
+}
+
+// alternatively
+$scope.callback = function (config) {
+  return $q(function (resolve) {
+      resolve({
+        data: ['a', 'b'],
+        status: 200,
+        config: {},
+        headers: function (headerName) {
+          // fake Content-Range headers
+          return '0-1/*';
+        }
+      });
+    }
+  );
+}
+```
 
 ### Further reading
 

--- a/src/paginate-anything.js
+++ b/src/paginate-anything.js
@@ -325,6 +325,10 @@
             }
           }, true);
 
+          $scope.$on('pagination:reload', function() {
+            $scope.reloadPage = true;
+          });
+
           var pp = $scope.perPage || defaultPerPage;
 
           if($scope.autoPresets) {

--- a/src/paginate-anything.js
+++ b/src/paginate-anything.js
@@ -75,6 +75,7 @@
           transformResponse: '=?',
           method: '@',
           postData: '=?',
+          loadFn: '&',
 
           // directive -> app communication only
           numPages: '=?',
@@ -87,11 +88,12 @@
           return attr.templateUrl || 'src/paginate-anything.html';
         },
         replace: true,
-        controller: ['$scope', '$http', function($scope, $http) {
+        controller: ['$scope', '$attrs', '$http', function($scope, $attrs, $http) {
 
           $scope.reloadPage   = false;
           $scope.serverLimit  = Infinity; // it's not known yet
           $scope.Math         = window.Math; // Math for the template
+          var useLoadFn       = $attrs.loadFn !== undefined; // directive's '&' params are always set, need to determine from $attrs whether to use loadFn
 
           if(typeof $scope.autoPresets !== 'boolean') {
             $scope.autoPresets = true;
@@ -147,9 +149,10 @@
           };
 
           function requestRange(request) {
-            if($scope.passive === 'true' || !$scope.url) { return; }
+            if($scope.passive === 'true' || !$scope.url && !useLoadFn) { return; }
             $scope.$emit('pagination:loadStart', request);
-            $http({
+
+            var config = {
               method: $scope.method || 'GET',
               url: $scope.url,
               params: $scope.urlParams,
@@ -159,14 +162,16 @@
                 { 'Range-Unit': 'items', Range: [request.from, request.to].join('-') }
               ),
               transformResponse: appendTransform($http.defaults.transformResponse, $scope.transformResponse)
-            }).success(function (data, status, headers, config) {
-              var response = parseRange(headers('Content-Range'));
-              if(status === 204 || (response && response.total === 0)) {
+            };
+            var responsePromise = useLoadFn ? $scope.loadFn({config: config}) : $http(config);
+            responsePromise.then(function (rsp) {
+              var response = parseRange(rsp.headers('Content-Range'));
+              if(rsp.status === 204 || (response && response.total === 0)) {
                 $scope.numItems = 0;
                 $scope.collection = [];
               } else {
-                $scope.numItems = response ? response.total : data.length;
-                $scope.collection = data || [];
+                $scope.numItems = response ? response.total : rsp.data.length;
+                $scope.collection = rsp.data || [];
               }
 
               if(response) {
@@ -197,9 +202,9 @@
               }
               $scope.numPages = Math.ceil($scope.numItems / ($scope.perPage || defaultPerPage));
 
-              $scope.$emit('pagination:loadPage', status, config);
-            }).error(function (data, status, headers, config) {
-              $scope.$emit('pagination:error', status, config);
+              $scope.$emit('pagination:loadPage', rsp.status, rsp.config);
+            }, function (rsp) {
+              $scope.$emit('pagination:error', rsp.status, rsp.config);
             });
           }
 

--- a/test/paginate-anything-spec.js
+++ b/test/paginate-anything-spec.js
@@ -196,6 +196,30 @@
       $httpBackend.verifyNoOutstandingRequest();
     });
 
+    it('performs search on pagination:reload event', function () {
+      scope.page = 0;
+      scope.perPage = 1;
+      $compile(template)(scope);
+
+      var get = $httpBackend.whenGET('/items');
+      get.respond(
+        finiteStringBackend('a', 1)
+      );
+      scope.$digest();
+      $httpBackend.flush();
+      expect(scope.collection).toEqual(['a']);
+
+      get.respond(
+        finiteStringBackend('b', 1)
+      );
+      scope.$broadcast('pagination:reload');
+      scope.$digest();
+      $httpBackend.flush();
+      expect(scope.collection).toEqual(['b']);
+
+      $httpBackend.verifyNoOutstandingRequest();
+    });
+
     it('can start on a different page', function () {
       scope.perPage = 25;
       scope.page = 1;


### PR DESCRIPTION
We needed the ability to further customize the http request and transform the reponse, so we introduced a new param to the directive to provide a callback.
We also needed to trigger a reload, so we added a new event.

The callback gets the http config to have all parameters like the range at hand and needs to return a promise.

This is how one could use the directive:

```html
<button ng-click="reload()">Reload results</button>
<bgf-pagination collection="data" page="filter.page" per-page="filter.perpage" load-fn="callback(config)"></bgf-pagination>
```

```javascript
// controller
$scope.reload = function () {
    $scope.$broadcast('pagination:reload');
}

$scope.callback = function (config) {
    return $http(config);
}
```

Alternatively
```javascript
// controller
$scope.callback = function (config) {
    return $q(function (resolve) {
            resolve({
                data: ['a', 'b'],
                status: 200,
                config: {},
                headers: function (headerName) {
                    // fake Content-Range headers
                    return '0-1/*';
                }
            });
        }
    );
}
```